### PR TITLE
remove warning message at '$ rails routes' caused by bootstrap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'rails', '~> 5.1.6'
 # Use Puma as the app server
 gem 'puma', '~> 3.7'
 # Use SCSS for stylesheets
-gem 'bootstrap-sass', '~> 3.3.7'
+
 gem 'bootstrap', '~> 4.1.3'
 gem 'bootstrap_form'
 gem 'bootstrap4-kaminari-views'


### PR DESCRIPTION
warning messages:
/usr/local/lib/ruby/gems/2.4.0/gems/bootstrap-4.1.3/lib/bootstrap/version.rb:2: warning: already initialized constantBootstrap::VERSION

/usr/local/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/lib/bootstrap-sass/version.rb:2: warning: previous definition of VERSION was here

/usr/local/lib/ruby/gems/2.4.0/gems/bootstrap-4.1.3/lib/bootstrap/version.rb:3: warning: already initialized constantBootstrap::BOOTSTRAP_SHA

/usr/local/lib/ruby/gems/2.4.0/gems/bootstrap-sass-3.3.7/lib/bootstrap-sass/version.rb:3: warning: previous definition of BOOTSTRAP_SHA was here

So I remove bootstrap-sass-3.3.7 and keep bootstrap-4.1.3 only.