### PR TITLE
save user avatar to aws s3 bucket for production environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,9 +84,8 @@ end
 
 group :production do
     gem 'pg', '~> 0.18'
+    gem "fog-aws"
 end
-  
-  
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,7 @@ GEM
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.7.1)
+    excon (0.62.0)
     execjs (2.7.0)
     factory_bot (4.11.0)
       activesupport (>= 3.0.0)
@@ -109,8 +110,25 @@ GEM
     ffi (1.9.25)
     figaro (1.1.1)
       thor (~> 0.14)
+    fog-aws (3.0.0)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (2.1.2)
+      builder
+      excon (~> 0.58)
+      formatador (~> 0.2)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.3)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
     font-awesome-rails (4.7.0.4)
       railties (>= 3.2, < 6.0)
+    formatador (0.2.5)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     hashie (3.5.7)
@@ -118,6 +136,7 @@ GEM
       domain_name (~> 0.5)
     i18n (1.1.0)
       concurrent-ruby (~> 1.0)
+    ipaddress (0.8.3)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
@@ -310,6 +329,7 @@ DEPENDENCIES
   factory_bot_rails
   ffaker
   figaro
+  fog-aws
   font-awesome-rails
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -4,8 +4,7 @@ class AvatarUploader < CarrierWave::Uploader::Base
   # include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
+  storage ENV["RAILS_ENV"] == "production" ? :fog : :file
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,11 +1,16 @@
 require 'fog/aws'
 CarrierWave.configure do |config|
-  config.fog_provider = 'fog/aws'                        # required
-  config.fog_credentials = {
-    provider:              'AWS',                        # required
-    aws_access_key_id:     ENV['AWS_ACCESS_KEY_ID'],     # required unless using use_iam_profile
-    aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'], # required unless using use_iam_profile
-    region:                ENV['S3_BUCKET_REGION'],      # optional, defaults to 'us-east-1'
-  }
-  config.fog_directory  = ENV['S3_BUCKET_NAME']          # required
+  if Rails.env.staging? || Rails.env.production?
+    config.fog_provider = 'fog/aws'                        # required
+    config.fog_credentials = {
+      provider:              'AWS',                        # required
+      aws_access_key_id:     ENV['AWS_ACCESS_KEY_ID'],     # required unless using use_iam_profile
+      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'], # required unless using use_iam_profile
+      region:                ENV['S3_BUCKET_REGION'],      # optional, defaults to 'us-east-1'
+    }
+    config.fog_directory  = ENV['S3_BUCKET_NAME']          # required
+  else
+    config.storage = :file
+    config.enable_processing = Rails.env.development?
+  end
 end

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,11 @@
+require 'fog/aws'
+CarrierWave.configure do |config|
+  config.fog_provider = 'fog/aws'                        # required
+  config.fog_credentials = {
+    provider:              'AWS',                        # required
+    aws_access_key_id:     ENV['AWS_ACCESS_KEY_ID'],     # required unless using use_iam_profile
+    aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'], # required unless using use_iam_profile
+    region:                ENV['S3_BUCKET_REGION'],      # optional, defaults to 'us-east-1'
+  }
+  config.fog_directory  = ENV['S3_BUCKET_NAME']          # required
+end

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,4 +1,3 @@
-require 'fog/aws'
 CarrierWave.configure do |config|
   if Rails.env.staging? || Rails.env.production?
     config.fog_provider = 'fog/aws'                        # required


### PR DESCRIPTION
## 在產品環境時，用戶的照片上傳儲存在aws s3 bucket。
測試網址 https://kidgamebata.herokuapp.com/

##
### Use fog-aws instead of requiring the full fog
ref : https://github.com/fog/fog#dependency-notice

