### PR TITLE
move app.js to the end of the body

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -31,4 +31,3 @@
 //= require wow.min
 //= require owl.carousel
 //= require turbolinks
-//= require app

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -299,6 +299,7 @@
     <div class="scrolling">
       <a href="#pageTop" class="backToTop hidden-xs" id="backToTop"><i class="fa fa-arrow-up" aria-hidden="true"></i></a>
     </div>
+  <%= javascript_include_tag 'app' %>
 </body>
 
 </html>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -13,3 +13,4 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
 Rails.application.config.assets.precompile << Proc.new { |path, fn| fn =~ /vendor\/assets\/images/ }
+Rails.application.config.assets.precompile << Proc.new { |path, fn| fn =~ /vendor\/assets\/javascripts/ }

--- a/vendor/assets/javascripts/app.js
+++ b/vendor/assets/javascripts/app.js
@@ -23,7 +23,7 @@ jQuery(document).ready(function(){
   'use strict';
   setTimeout(function(){
 		$('body').addClass('loaded');
-	}, 3000);
+	}, 1000);
 
   /*======== 2. MENU SCROLL ========*/
    $(window).on('load', function(){


### PR DESCRIPTION
- 開網頁會一直轉轉的東西叫做preloader,是放在vendor/assets/javascripts/app.js

- 我發現在版型的sample網頁index.html在app.js放在body的最後一行，所以我把app.js移到body的最後一行後，網頁preloader轉一下下網頁就開出來了。

- preloader是在application中，每次都會執行，版型預設值是轉3秒，我改成轉1秒

- 結論就是：preloader轉一秒後，網頁就開出來了